### PR TITLE
Drop platform: advice to shutdown workers

### DIFF
--- a/app/client.ml
+++ b/app/client.ml
@@ -134,6 +134,11 @@ let drop_platform () remote name =
     r;
   r
 
+let undrop_platform () remote name =
+  let* s = connect remote in
+  let* () = Builder.write_cmd s (Builder.Undrop_platform name) in
+  teardown s
+
 let help () man_format cmds = function
   | None -> `Help (`Pager, None)
   | Some t when List.mem t cmds -> `Help (man_format, Some t)
@@ -301,10 +306,21 @@ let drop_platform_cmd =
   in
   Cmd.v info term
 
+let undrop_platform_cmd =
+  let platform =
+    let doc = "The platform to undrop." in
+    Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"PLATFORM")
+  in
+  let term =
+    Term.(term_result (const undrop_platform $ setup_log $ remote $ platform))
+  and info = Cmd.info "undrop-platform"
+  in
+  Cmd.v info term
+
 let help_cmd =
   Term.(ret (const help $ setup_log $ Arg.man_format $ Term.choice_names $ Term.const None))
 
-let cmds = [ schedule_cmd ; unschedule_cmd ; info_cmd ; observe_latest_cmd ; observe_cmd ; execute_cmd ; schedule_orb_build_cmd ; reschedule_cmd ; drop_platform_cmd ]
+let cmds = [ schedule_cmd ; unschedule_cmd ; info_cmd ; observe_latest_cmd ; observe_cmd ; execute_cmd ; schedule_orb_build_cmd ; reschedule_cmd ; drop_platform_cmd ; undrop_platform_cmd ]
 
 let () =
   let doc = "Builder client" in

--- a/app/client.ml
+++ b/app/client.ml
@@ -130,7 +130,7 @@ let drop_platform () remote name =
                              Remember to disable workers for that platform. \
                              Workers for %s still running will recreate \
                              the platform."
-                    name))
+                    name name))
     r;
   r
 

--- a/app/client.ml
+++ b/app/client.ml
@@ -123,7 +123,16 @@ let reschedule () remote name next period =
 let drop_platform () remote name =
   let* s = connect remote in
   let* () = Builder.write_cmd s (Builder.Drop_platform name) in
-  teardown s
+  let r = teardown s in
+  Result.iter
+    (fun () ->
+       Logs.app (fun m -> m "Platform %s dropped. \
+                             Remember to disable workers for that platform. \
+                             Workers for %s still running will recreate \
+                             the platform."
+                    name))
+    r;
+  r
 
 let help () man_format cmds = function
   | None -> `Help (`Pager, None)
@@ -283,7 +292,7 @@ let execute_cmd =
 
 let drop_platform_cmd =
   let platform =
-    let doc = "The platform to drop" in
+    let doc = "The platform to drop. Remember to disable relevant workers as well." in
     Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"PLATFORM")
   in
   let term =


### PR DESCRIPTION
When dropping a platform it is best to first disable the relevant workers. Otherwise the workers will eventually recreate the platform.

Fixes #38 