### PR TITLE
Use /job/_/build/_/main-binary alias

### DIFF
--- a/FreeBSD/jail.conf
+++ b/FreeBSD/jail.conf
@@ -6,11 +6,11 @@ mount.devfs;
 exec.clean;
 
 orba {
-   exec.start = "pkg install -fy pkg && pkg install -y ca_root_nss && fetch -o builder.pkg 'https://builds.robur.coop/job/builder/build/latest/f/bin/builder.pkg?platform=freebsd-12' && pkg install -y builder.pkg && rm builder.pkg && /usr/local/libexec/builder-worker freebsd-12 --remote 127.0.2.1:1234";
+   exec.start = "pkg install -fy pkg && pkg install -y ca_root_nss && fetch -o builder.pkg 'https://builds.robur.coop/job/builder/build/latest/main-binary?platform=freebsd-12' && pkg install -y builder.pkg && rm builder.pkg && /usr/local/libexec/builder-worker freebsd-12 --remote 127.0.2.1:1234";
    ip4.addr=127.0.2.2;
 }
 
 orbb {
-   exec.start = "pkg install -fy pkg && pkg install -y ca_root_nss && fetch -o builder.pkg 'https://builds.robur.coop/job/builder-freebsd/build/latest/f/bin/builder.pkg?platform=freebsd-12' && pkg install -y builder.pkg && rm builder.pkg && /usr/local/libexec/builder-worker freebsd-12 --remote 127.0.2.1:1234";
+   exec.start = "pkg install -fy pkg && pkg install -y ca_root_nss && fetch -o builder.pkg 'https://builds.robur.coop/job/builder-freebsd/build/latest/main-binary?platform=freebsd-12' && pkg install -y builder.pkg && rm builder.pkg && /usr/local/libexec/builder-worker freebsd-12 --remote 127.0.2.1:1234";
    ip4.addr=127.0.2.3;
 }

--- a/Linux/builder-worker.service
+++ b/Linux/builder-worker.service
@@ -10,7 +10,7 @@ Environment=DOCKER_IMAGE=ubuntu:20.04
 ExecStart=/usr/bin/docker run --rm --name %n ${DOCKER_IMAGE} sh -c \
  'apt update; \
   apt install --no-install-recommends --no-install-suggests -y wget ca-certificates; \
-  wget -O builder.deb "https://builds.robur.coop/job/builder/build/latest/f/bin/builder.deb?platform=${BUILDER_PLATFORM}"; \
+  wget -O builder.deb "https://builds.robur.coop/job/builder/build/latest/main-binary?platform=${BUILDER_PLATFORM}"; \
   apt install -y ./builder.deb; \
   builder-worker -r 172.17.0.1:1234 ${BUILDER_PLATFORM}'
 ExecStop=/usr/bin/docker stop %n

--- a/packaging/orb-build.template.freebsd
+++ b/packaging/orb-build.template.freebsd
@@ -2,7 +2,7 @@
 
 set -ex
 
-fetch -o orb.pkg 'https://builds.robur.coop/job/orb/build/latest/f/bin/orb.pkg?platform=%%PLATFORM%%' && pkg install -y orb.pkg && rm orb.pkg
+fetch -o orb.pkg 'https://builds.robur.coop/job/orb/build/latest/main-binary?platform=%%PLATFORM%%' && pkg install -y orb.pkg && rm orb.pkg
 
 repos="default:https://opam.ocaml.org,unikernels:https://git.robur.coop/robur/unikernel-repo.git"
 orb build --solver-timeout=600 --switch-name=/tmp/myswitch --date=1589138087 --out=. --repos=$repos %%OPAM_PACKAGE%%

--- a/packaging/orb-build.template.ubuntu-20.04
+++ b/packaging/orb-build.template.ubuntu-20.04
@@ -2,7 +2,7 @@
 
 set -ex
 
-wget -O orb.deb 'https://builds.robur.coop/job/orb/build/latest/f/bin/orb.deb?platform=%%PLATFORM%%'
+wget -O orb.deb 'https://builds.robur.coop/job/orb/build/latest/main-binary?platform=%%PLATFORM%%'
 apt install --no-install-recommends --no-install-suggests -y ./orb.deb
 rm orb.deb
 


### PR DESCRIPTION
This is useful for bootstrapping as the `/job/_/platform/_/upload` defaults to using `<job-name>.bin` for the main binary if the user forgets to pass the undocumented `?binary_name` query parameter when uploading a binary manually. This alias has been in builder-web for quite a while now.

The downside is if a change in main binary name is intentional; then this change hides this fact.