### PR TITLE
Don't catch Lwt.Canceled exceptions in read

### DIFF
--- a/app/server.ml
+++ b/app/server.ml
@@ -22,7 +22,9 @@ let read fd =
       let b = Bytes.create l_int in
       r b l_int >|= fun () ->
       Bytes.unsafe_to_string b)
-    (fun e ->
+    (function
+      | Lwt.Canceled as e -> Lwt.reraise e
+      | e ->
        Logs.err (fun m -> m "Error while reading: %s" (Printexc.to_string e));
        Lwt.return (Error (`Msg "error in read")))
 


### PR DESCRIPTION
In the logs I saw this after a stalled build. I think there are more issues around, but this fixes the spurious error log message.
```
Jan 17 10:40:52 poudriere daemon[711]: builder-server: [WARNING] ab873583-1d75-43c4-b973-d3f54ab4aaf7 timeout after 3600.000000 seconds
Jan 17 10:40:52 poudriere daemon[711]: builder-server: [ERROR] Error while reading: Lwt.Resolution_loop.Canceled
Jan 17 10:40:52 poudriere daemon[711]: builder-server: [WARNING] ab873583-1d75-43c4-b973-d3f54ab4aaf7 communication failure error in read with name builder-web, opam builder-web, job 127.0.2.2:18886 put back
Jan 17 10:40:52 poudriere daemon[711]: builder-server: [WARNING] ab873583-1d75-43c4-b973-d3f54ab4aaf7 timed out
Jan 17 10:40:52 poudriere daemon[711]: builder-server: [ERROR] no job found for uuid ab873583-1d75-43c4-b973-d3f54ab4aaf7
```