### PR TITLE
Drop one message, not all remaining

### DIFF
--- a/app/server.ml
+++ b/app/server.ml
@@ -577,7 +577,7 @@ let client_loop t fd =
               more ()
             end else
               (* Drop data messages if the client can't keep up *)
-              Lwt.return_unit
+              more ()
         in
         let rec send () =
           if Queue.is_empty q then


### PR DESCRIPTION
I think this explains why things get stuck when I run `builder-client observe-latest`. At some point I don't see more messages.