### PR TITLE
Close connection to worker

### DIFF
--- a/app/server.ml
+++ b/app/server.ml
@@ -450,6 +450,7 @@ let worker_loop t addr fd =
           Lwt.pick [ timeout () ; read_worker () ] >>= function
           | `Timeout ->
             Logs.warn (fun m -> m "%a timed out" Uuidm.pp uuid);
+            Lwt_unix.close fd >>= fun () ->
             job_finished t uuid (Builder.Msg "timeout") [] >|= fun () ->
             add_to_queue t platform job;
             ignore (dump t)

--- a/app/server.ml
+++ b/app/server.ml
@@ -454,7 +454,7 @@ let worker_loop t addr fd =
             job_finished t uuid (Builder.Msg "timeout") [] >|= fun () ->
             add_to_queue t platform job;
             ignore (dump t)
-          | `Done -> Lwt.return_unit
+          | `Done -> Lwt_unix.close fd
     end
   | Ok cmd ->
     Logs.err (fun m -> m "unexpected %a" Builder.pp_cmd cmd);


### PR DESCRIPTION
I don't know if we need a "safe_close" here. We should only be closing the connection once, so it's probably not needed. Though I don't know what close does if the remote closed the connection first.